### PR TITLE
Position publisher interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ add_compile_options(-Wall -Werror=all)
 add_compile_options(-Wextra -Werror=extra)
 
 find_package(catkin REQUIRED COMPONENTS
-    geolib2
     geometry_msgs
     sensor_msgs
     roscpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ add_compile_options(-Wall -Werror=all)
 add_compile_options(-Wextra -Werror=extra)
 
 find_package(catkin REQUIRED COMPONENTS
+    geolib2
     geometry_msgs
     sensor_msgs
     roscpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ find_package(catkin REQUIRED COMPONENTS
     geometry_msgs
     sensor_msgs
     roscpp
-    message_generation    
+    message_generation
+    tf2_ros    
 )
 
 # find_package(Boost REQUIRED COMPONENTS system program_options)

--- a/include/emc/communication.h
+++ b/include/emc/communication.h
@@ -74,8 +74,6 @@ private:
 
     // Position data
 
-    ros::Publisher pub_joints;
-
     tf2_ros::TransformBroadcaster* pub_tf2; //has to be defined after ros::init(), which is called in the constructor
 
 

--- a/include/emc/communication.h
+++ b/include/emc/communication.h
@@ -9,6 +9,7 @@
 #include <ros/subscriber.h>
 #include <ros/callback_queue.h>
 #include <tf2_ros/transform_broadcaster.h>
+#include <nav_msgs/MapMetaData.h>
 
 #include <std_msgs/Bool.h>
 #include <sensor_msgs/LaserScan.h>
@@ -18,6 +19,11 @@
 
 namespace emc
 {
+
+struct MapConfig{
+    double mapResolution, mapOffsetX, mapOffsetY, mapOrientation;
+    bool mapInitialised;
+};
 
 class Communication
 {
@@ -48,7 +54,10 @@ public:
     void play(const std::string& file);
 
     // Postion data
-    void sendPoseEstimate(geometry_msgs::Transform& pose);
+    void sendPoseEstimate(const geometry_msgs::Transform& pose);
+
+    // Map data
+    MapConfig mapconfig;
 
 private:
 
@@ -62,7 +71,7 @@ private:
     
     ros::Publisher pub_play_;
 
-    tf2_ros::TransformBroadcaster pub_tf2;
+    tf2_ros::TransformBroadcaster* pub_tf2; //has to be defined after ros::init(), which is called in the constructor
 
 
     // Laser data
@@ -99,6 +108,12 @@ private:
 
     void bumperfCallback(const std_msgs::BoolConstPtr& msg);
     void bumperbCallback(const std_msgs::BoolConstPtr& msg);
+
+    // Map data
+
+    ros::Subscriber sub_mapdata;
+
+    void mapCallback(const nav_msgs::MapMetaData::ConstPtr& msg);
 
 /*
     // Control effort data

--- a/include/emc/communication.h
+++ b/include/emc/communication.h
@@ -9,6 +9,7 @@
 #include <ros/subscriber.h>
 #include <ros/callback_queue.h>
 #include <tf2_ros/transform_broadcaster.h>
+#include <sensor_msgs/JointState.h>
 #include <nav_msgs/MapMetaData.h>
 
 #include <std_msgs/Bool.h>
@@ -70,6 +71,10 @@ private:
     ros::Publisher pub_speak_;
     
     ros::Publisher pub_play_;
+
+    // Position data
+
+    ros::Publisher pub_joints;
 
     tf2_ros::TransformBroadcaster* pub_tf2; //has to be defined after ros::init(), which is called in the constructor
 

--- a/include/emc/communication.h
+++ b/include/emc/communication.h
@@ -58,6 +58,8 @@ private:
     
     ros::Publisher pub_play_;
 
+    tf2_ros::TransformBroadcaster pub_tf2;
+
 
     // Laser data
 
@@ -105,6 +107,8 @@ private:
 
     void controlEffortCallback(const emc_system::controlEffortConstPtr& msg);
 */
+    // Postion data
+    void sendPositionEstimate(geometry_msgs::Transform& pose);
 
 };
 

--- a/include/emc/communication.h
+++ b/include/emc/communication.h
@@ -57,7 +57,7 @@ public:
     void sendPoseEstimate(const geometry_msgs::Transform& pose);
 
     // Map data
-    MapConfig mapconfig;
+    MapConfig getMapConfig();
 
 private:
 
@@ -111,7 +111,11 @@ private:
 
     // Map data
 
-    ros::Subscriber sub_mapdata;
+    ros::CallbackQueue mapdata_cb_queue_;
+
+    ros::Subscriber sub_mapdata_;
+
+    MapConfig mapconfig;
 
     void mapCallback(const nav_msgs::MapMetaData::ConstPtr& msg);
 

--- a/include/emc/communication.h
+++ b/include/emc/communication.h
@@ -58,7 +58,7 @@ public:
     void sendPoseEstimate(const geometry_msgs::Transform& pose);
 
     // Map data
-    MapConfig getMapConfig();
+    bool getMapConfig(MapConfig& config);
 
 private:
 

--- a/include/emc/communication.h
+++ b/include/emc/communication.h
@@ -8,6 +8,7 @@
 #include <ros/publisher.h>
 #include <ros/subscriber.h>
 #include <ros/callback_queue.h>
+#include <tf2_ros/transform_broadcaster.h>
 
 #include <std_msgs/Bool.h>
 #include <sensor_msgs/LaserScan.h>
@@ -45,6 +46,9 @@ public:
     void speak(const std::string& text);
     
     void play(const std::string& file);
+
+    // Postion data
+    void sendPoseEstimate(geometry_msgs::Transform& pose);
 
 private:
 
@@ -107,8 +111,7 @@ private:
 
     void controlEffortCallback(const emc_system::controlEffortConstPtr& msg);
 */
-    // Postion data
-    void sendPositionEstimate(geometry_msgs::Transform& pose);
+    
 
 };
 

--- a/include/emc/io.h
+++ b/include/emc/io.h
@@ -8,6 +8,8 @@
 #include "emc/odom.h"
 #include "emc/bumper.h"
 
+#include <geolib/datatypes.h>
+
 namespace emc
 {
 
@@ -41,6 +43,13 @@ public:
     void speak(const std::string& text);
     
     void play(const std::string& file);
+
+    void sendPoseEstimate(double& px, double& py, double& pz, double& rx, double& ry, double& rz, double& rw); //use quaternion
+
+    void sendPoseEstimate(double& px, double& py, double& pz, double& rr, double& rp, double& ry); //use roll pitch yaw
+
+    void sendPoseEstimate(geo::pose3D& pose); //use pose
+
 
 private:
 

--- a/include/emc/io.h
+++ b/include/emc/io.h
@@ -8,8 +8,6 @@
 #include "emc/odom.h"
 #include "emc/bumper.h"
 
-#include <geolib/datatypes.h>
-
 namespace emc
 {
 
@@ -44,12 +42,9 @@ public:
     
     void play(const std::string& file);
 
-    void sendPoseEstimate(double& px, double& py, double& pz, double& rx, double& ry, double& rz, double& rw); //use quaternion
+    void sendPoseEstimate(const double& px, const double& py, const double& pz, const double& rx, const double& ry, const double& rz, const double& rw); //use quaternion
 
-    void sendPoseEstimate(double& px, double& py, double& pz, double& rr, double& rp, double& ry); //use roll pitch yaw
-
-    void sendPoseEstimate(geo::pose3D& pose); //use pose
-
+    void sendPoseEstimate(const double& px, const double& py, const double& pz, const double& rr, const double& rp, const double& ry); //use roll pitch yaw
 
 private:
 

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -234,5 +234,15 @@ void Communication::controlEffortCallback(const emc_system::controlEffortConstPt
 }
 */
 
+void Communication::sendPoseEstimate(geometry_msgs::Transform& pose)
+{
+    geometry_msgs::TransformStamped transformStamped;
+    transformStamped.header.stamp = ros::Time::now();
+    transformStamped.header.frame_id = "map";
+    transformStamped.child_frame_id = "/base_link";
+    transformStamped.transform = pose;
+    pub_tf2.sendTransform(transformStamped);
+}
+
 } // end namespace emc
 

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -62,6 +62,7 @@ Communication::Communication(std::string /*robot_name*/)
     pub_speak_ = nh.advertise<std_msgs::String>(speak_param, 1);
     pub_play_ = nh.advertise<std_msgs::String>(play_param, 1);
 
+    pub_joints = nh.advertise<sensor_msgs::JointState>("/viz_internal/joint_states", 1);
     pub_tf2 = new tf2_ros::TransformBroadcaster;
 }
 
@@ -209,10 +210,21 @@ void Communication::play(const std::string& file)
 
 void Communication::sendPoseEstimate(const geometry_msgs::Transform& pose)
 {
+    // Publish jointstate
+    sensor_msgs::JointState jointState;
+    jointState.header.stamp = ros::Time::now();
+    jointState.name = {"front_left_wheel_hinge", 
+                       "front_right_wheel_hinge", 
+                       "rear_left_wheel_hinge", 
+                       "rear_right_wheel_hinge"};
+    jointState.position = {0, 0, 0, 0};
+    pub_joints.publish(jointState);
+
+    // Publish tf transform
     geometry_msgs::TransformStamped transformStamped;
     transformStamped.header.stamp = ros::Time::now();
     transformStamped.header.frame_id = "map";
-    transformStamped.child_frame_id = "/base_link";
+    transformStamped.child_frame_id = "internal/base_link";
     transformStamped.transform = pose;
     pub_tf2->sendTransform(transformStamped);
 }

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -2,6 +2,8 @@
 
 #include <ros/node_handle.h>
 #include <ros/subscribe_options.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
 
 #include <geometry_msgs/Twist.h>
 #include <std_msgs/Empty.h>
@@ -50,18 +52,23 @@ Communication::Communication(std::string /*robot_name*/)
     ros::SubscribeOptions bumper_b_sub_options = ros::SubscribeOptions::create<std_msgs::Bool>(bumper_b_param, 1, boost::bind(&Communication::bumperbCallback, this, _1), ros::VoidPtr(), &bumper_b_cb_queue_);
     sub_bumper_b_ = nh.subscribe(bumper_b_sub_options);
 
+    sub_mapdata = nh.subscribe<nav_msgs::MapMetaData>("/map_metadata",1, &Communication::mapCallback, this);
+
     pub_base_ref_ = nh.advertise<geometry_msgs::Twist>(base_ref_param, 1);
 
     pub_open_door_ = nh.advertise<std_msgs::Empty>(open_door_param, 1);
 
     pub_speak_ = nh.advertise<std_msgs::String>(speak_param, 1);
     pub_play_ = nh.advertise<std_msgs::String>(play_param, 1);
+
+    pub_tf2 = new tf2_ros::TransformBroadcaster;
 }
 
 // ----------------------------------------------------------------------------------------------------
 
 Communication::~Communication()
 {
+    delete pub_tf2;
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -199,14 +206,14 @@ void Communication::play(const std::string& file)
     pub_play_.publish(str);
 }
 
-void Communication::sendPoseEstimate(geometry_msgs::Transform& pose)
+void Communication::sendPoseEstimate(const geometry_msgs::Transform& pose)
 {
     geometry_msgs::TransformStamped transformStamped;
     transformStamped.header.stamp = ros::Time::now();
     transformStamped.header.frame_id = "map";
     transformStamped.child_frame_id = "/base_link";
     transformStamped.transform = pose;
-    pub_tf2.sendTransform(transformStamped);
+    pub_tf2->sendTransform(transformStamped);
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -235,6 +242,29 @@ void Communication::bumperfCallback(const std_msgs::BoolConstPtr& msg)
 void Communication::bumperbCallback(const std_msgs::BoolConstPtr& msg)
 {
     bumper_b_msg_ = msg;
+}
+
+void Communication::mapCallback(const nav_msgs::MapMetaData::ConstPtr& msg)
+{
+    ROS_INFO_STREAM("Reading map");
+    mapconfig.mapResolution = msg->resolution;
+    mapconfig.mapOffsetX =  ((msg->height)*msg->resolution)/2;
+    mapconfig.mapOffsetY = -((msg->width)*msg->resolution)/2;
+
+    tf2::Quaternion q(msg->origin.orientation.x, 
+                      msg->origin.orientation.y, 
+                      msg->origin.orientation.z, 
+                      msg->origin.orientation.w);
+
+    tf2::Matrix3x3 T(q);
+
+    double roll, pitch, yaw;
+    T.getRPY(roll, pitch, yaw);
+
+    mapconfig.mapOrientation = yaw + M_PI/2;
+    mapconfig.mapInitialised = true;
+    ROS_INFO_STREAM("Map parameters:" << mapconfig.mapOffsetX << mapconfig.mapOffsetY << mapconfig.mapOrientation);
+    sub_mapdata.shutdown();
 }
 // ----------------------------------------------------------------------------------------------------
 /*

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -246,7 +246,6 @@ void Communication::bumperbCallback(const std_msgs::BoolConstPtr& msg)
 
 void Communication::mapCallback(const nav_msgs::MapMetaData::ConstPtr& msg)
 {
-    ROS_INFO_STREAM("Reading map");
     mapconfig.mapResolution = msg->resolution;
     mapconfig.mapOffsetX =  ((msg->height)*msg->resolution)/2;
     mapconfig.mapOffsetY = -((msg->width)*msg->resolution)/2;
@@ -263,7 +262,7 @@ void Communication::mapCallback(const nav_msgs::MapMetaData::ConstPtr& msg)
 
     mapconfig.mapOrientation = yaw + M_PI/2;
     mapconfig.mapInitialised = true;
-    ROS_INFO_STREAM("Map parameters:" << mapconfig.mapOffsetX << mapconfig.mapOffsetY << mapconfig.mapOrientation);
+    ROS_INFO_STREAM("Map data loaded");
     sub_mapdata.shutdown();
 }
 // ----------------------------------------------------------------------------------------------------

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -199,6 +199,16 @@ void Communication::play(const std::string& file)
     pub_play_.publish(str);
 }
 
+void Communication::sendPoseEstimate(geometry_msgs::Transform& pose)
+{
+    geometry_msgs::TransformStamped transformStamped;
+    transformStamped.header.stamp = ros::Time::now();
+    transformStamped.header.frame_id = "map";
+    transformStamped.child_frame_id = "/base_link";
+    transformStamped.transform = pose;
+    pub_tf2.sendTransform(transformStamped);
+}
+
 // ----------------------------------------------------------------------------------------------------
 
 void Communication::laserCallback(const sensor_msgs::LaserScanConstPtr& msg)
@@ -233,16 +243,6 @@ void Communication::controlEffortCallback(const emc_system::controlEffortConstPt
     ce_msg_ = msg;
 }
 */
-
-void Communication::sendPoseEstimate(geometry_msgs::Transform& pose)
-{
-    geometry_msgs::TransformStamped transformStamped;
-    transformStamped.header.stamp = ros::Time::now();
-    transformStamped.header.frame_id = "map";
-    transformStamped.child_frame_id = "/base_link";
-    transformStamped.transform = pose;
-    pub_tf2.sendTransform(transformStamped);
-}
 
 } // end namespace emc
 

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -229,9 +229,10 @@ void Communication::sendPoseEstimate(const geometry_msgs::Transform& pose)
     pub_tf2->sendTransform(transformStamped);
 }
 
-MapConfig Communication::getMapConfig() {
+bool Communication::getMapConfig(MapConfig& config) {
     if (!mapconfig.mapInitialised) {mapdata_cb_queue_.callAvailable();}//try to initialise the map
-    return mapconfig;
+    config = mapconfig;
+    return mapconfig.mapInitialised;
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -62,7 +62,6 @@ Communication::Communication(std::string /*robot_name*/)
     pub_speak_ = nh.advertise<std_msgs::String>(speak_param, 1);
     pub_play_ = nh.advertise<std_msgs::String>(play_param, 1);
 
-    pub_joints = nh.advertise<sensor_msgs::JointState>("/viz_internal/joint_states", 1);
     pub_tf2 = new tf2_ros::TransformBroadcaster;
 }
 
@@ -210,16 +209,6 @@ void Communication::play(const std::string& file)
 
 void Communication::sendPoseEstimate(const geometry_msgs::Transform& pose)
 {
-    // Publish jointstate
-    sensor_msgs::JointState jointState;
-    jointState.header.stamp = ros::Time::now();
-    jointState.name = {"front_left_wheel_hinge", 
-                       "front_right_wheel_hinge", 
-                       "rear_left_wheel_hinge", 
-                       "rear_right_wheel_hinge"};
-    jointState.position = {0, 0, 0, 0};
-    pub_joints.publish(jointState);
-
     // Publish tf transform
     geometry_msgs::TransformStamped transformStamped;
     transformStamped.header.stamp = ros::Time::now();

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -3,6 +3,9 @@
 #include "emc/communication.h"
 
 #include <ros/init.h>  // for ros::ok()
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/Quaternion.h>
+#include <geometry_msgs/Vector3.h>
 
 #include <string>
 
@@ -85,6 +88,32 @@ void IO::play(const std::string& file)
 bool IO::ok()
 {
     return ros::ok();
+}
+
+void IO::sendPoseEstimate(double& px, double& py, double& pz, double& rx, double& ry, double& rz, double& rw)
+{
+    geometry_msgs::Transform pose;
+    pose.translation.x = px;
+    pose.translation.y = py;
+    pose.translation.z = pz;
+    pose.rotation.x = rx;
+    pose.rotation.y = ry;
+    pose.rotation.z = rz;
+    pose.rotation.w = rw;
+
+}
+
+void IO::sendPoseEstimate(double& px, double& py, double& pz, double& rr, double& rp, double& ry)
+{
+    tf2::quaternion q;
+    q.setRPY(rr, rp, ry);
+    this->sendPoseEstimate(px, py, pz, q.x(), q.y(), q.z(), q.w())
+}
+
+void IO::sendPoseEstimate(geo::Pose3D pose)
+{
+    double px, py, pz, rx, ry, rz, rw;
+
 }
 
 }

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -96,16 +96,16 @@ void IO::sendPoseEstimate(const double& px, const double& py, const double& pz, 
 {
     // apply map offset and send to comm_
     tf2::Transform pose;
+    MapConfig mapData = comm_->getMapConfig();
 
     pose.setOrigin(tf2::Vector3(px, py, pz));
     pose.setRotation(tf2::Quaternion(rx, ry, rz, rw));
-    if (!comm_->mapconfig.mapInitialised) {ros::spinOnce();} //check if map data can be read
-    if (comm_->mapconfig.mapInitialised)
+    if (mapData.mapInitialised)
     {
         tf2::Transform mapOffset;
-        mapOffset.setOrigin(tf2::Vector3(comm_->mapconfig.mapOffsetX, comm_->mapconfig.mapOffsetY, 0));
+        mapOffset.setOrigin(tf2::Vector3(mapData.mapOffsetX, mapData.mapOffsetY, 0));
         tf2::Quaternion q;
-        q.setRPY(0, 0, comm_->mapconfig.mapOrientation);
+        q.setRPY(0, 0, mapData.mapOrientation);
         mapOffset.setRotation(q);
 
         pose = pose * mapOffset;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -99,7 +99,7 @@ void IO::sendPoseEstimate(const double& px, const double& py, const double& pz, 
 
     pose.setOrigin(tf2::Vector3(px, py, pz));
     pose.setRotation(tf2::Quaternion(rx, ry, rz, rw));
-
+    if (!comm_->mapconfig.mapInitialised) {ros::spinOnce();} //check if map data can be read
     if (comm_->mapconfig.mapInitialised)
     {
         tf2::Transform mapOffset;
@@ -110,6 +110,8 @@ void IO::sendPoseEstimate(const double& px, const double& py, const double& pz, 
 
         pose = pose * mapOffset;
     }
+
+    else{ROS_WARN_STREAM("No map data supplied");}
 
     comm_->sendPoseEstimate(tf2::toMsg(pose));
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -96,11 +96,11 @@ void IO::sendPoseEstimate(const double& px, const double& py, const double& pz, 
 {
     // apply map offset and send to comm_
     tf2::Transform pose;
-    MapConfig mapData = comm_->getMapConfig();
-
+    MapConfig mapData;
     pose.setOrigin(tf2::Vector3(px, py, pz));
     pose.setRotation(tf2::Quaternion(rx, ry, rz, rw));
-    if (mapData.mapInitialised)
+
+    if (comm_->getMapConfig(mapData))
     {
         tf2::Transform mapOffset;
         mapOffset.setOrigin(tf2::Vector3(mapData.mapOffsetX, mapData.mapOffsetY, 0));

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -3,6 +3,7 @@
 #include "emc/communication.h"
 
 #include <ros/init.h>  // for ros::ok()
+#include <tf2/LinearMath/Quaternion.h>
 #include <geometry_msgs/Pose.h>
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Vector3.h>
@@ -90,7 +91,7 @@ bool IO::ok()
     return ros::ok();
 }
 
-void IO::sendPoseEstimate(double& px, double& py, double& pz, double& rx, double& ry, double& rz, double& rw)
+void IO::sendPoseEstimate(const double& px, const double& py, const double& pz, const double& rx, const double& ry, const double& rz, const double& rw)
 {
     geometry_msgs::Transform pose;
     pose.translation.x = px;
@@ -101,19 +102,15 @@ void IO::sendPoseEstimate(double& px, double& py, double& pz, double& rx, double
     pose.rotation.z = rz;
     pose.rotation.w = rw;
 
+    comm_->sendPoseEstimate(pose);
+
 }
 
-void IO::sendPoseEstimate(double& px, double& py, double& pz, double& rr, double& rp, double& ry)
+void IO::sendPoseEstimate(const double& px, const double& py, const double& pz, const double& rr, const double& rp, const double& ry)
 {
-    tf2::quaternion q;
+    tf2::Quaternion q;
     q.setRPY(rr, rp, ry);
-    this->sendPoseEstimate(px, py, pz, q.x(), q.y(), q.z(), q.w())
-}
-
-void IO::sendPoseEstimate(geo::Pose3D pose)
-{
-    double px, py, pz, rx, ry, rz, rw;
-
+    this->sendPoseEstimate(px, py, pz, double(q.x()), double(q.y()), double(q.z()), double(q.w()));
 }
 
 }


### PR DESCRIPTION
Adds an interface to publish the internal expected position of the robot for use in rviz. Requires internal state support (emc_simulator).