### PR TITLE
Odom interface

### DIFF
--- a/examples/test_io.cpp
+++ b/examples/test_io.cpp
@@ -9,7 +9,7 @@ int main()
     emc::IO io;
 
     // Create Rate object, which will help using keeping the loop at a fixed frequency
-    emc::Rate r(100);
+    emc::Rate r(10);
 
     // Loop while we are properly connected
     while(io.ok())

--- a/include/emc/io.h
+++ b/include/emc/io.h
@@ -43,6 +43,13 @@ public:
     bool readOdometryData(OdometryData& odom);
 
     /**
+     * @brief Set the current position as (0,0,0)
+     * 
+     * @return true if new data was available to reset, false if not
+    */
+    bool resetOdometry();
+
+    /**
      * @brief Receive new BumperData from the front bumper
      * 
      * @param bumper Bumberdata object to write the new data to, untouched if no data is available
@@ -147,6 +154,7 @@ private:
      */
     bool sendPoseEstimate(double px, double py, double pz, double rr, double rp, double ry); //use roll pitch yaw
 
+    OdometryData prev_odom;
     Communication* comm_;
 
 };

--- a/include/emc/io.h
+++ b/include/emc/io.h
@@ -156,8 +156,8 @@ private:
     bool sendPoseEstimate(double px, double py, double pz, double rr, double rp, double ry); //use roll pitch yaw
 
     // odometry memory
-    OdometryData prev_odom;
-    bool odom_set = false; // wether odom has been set at least once.
+    OdometryData prev_odom_;
+    bool odom_set_ = false; // wether odom has been set at least once.
 
     Communication* comm_;
 

--- a/include/emc/io.h
+++ b/include/emc/io.h
@@ -36,7 +36,8 @@ public:
     /**
      * @brief Receive new odometrydata if available
      * 
-     * @param odom reference to an OdometryData object to write the new data to
+     * @param[out] odom reference to an OdometryData object to write the new data to. provides displacement since
+     *  last time this function or resetOdometry() was called.
      * @return true if new data was available
      * @return false if not
      */
@@ -154,7 +155,10 @@ private:
      */
     bool sendPoseEstimate(double px, double py, double pz, double rr, double rp, double ry); //use roll pitch yaw
 
+    // odometry memory
     OdometryData prev_odom;
+    bool odom_set = false; // wether odom has been set at least once.
+
     Communication* comm_;
 
 };

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -54,7 +54,7 @@ bool IO::readOdometryData(OdometryData& odom)
     double dx = new_odom.x - prev_odom_.x;
     double dy = new_odom.y - prev_odom_.y;
     odom.x = cos(prev_odom_.a) * dx + sin(prev_odom_.a) * dy;
-    odom.y = -sin(prev_odom.a) * dx + cos(prev_odom.a) * dy;
+    odom.y = -sin(prev_odom_.a) * dx + cos(prev_odom_.a) * dy;
     odom.a = fmod(new_odom.a - prev_odom_.a + M_PI, 2*M_PI) - M_PI;
 
     prev_odom_ = new_odom;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -52,13 +52,13 @@ bool IO::readOdometryData(OdometryData& odom)
     }
 
     odom.timestamp = new_odom.timestamp; //TODO give dt?
-    double dx = new_odom.x - prev_odom.x;
-    double dy = new_odom.y - prev_odom.y;
-    odom.x = cos(prev_odom.a) * dx + sin(prev_odom.a) * dy;
+    double dx = new_odom.x - prev_odom_.x;
+    double dy = new_odom.y - prev_odom_.y;
+    odom.x = cos(prev_odom_.a) * dx + sin(prev_odom_.a) * dy;
     odom.y = -sin(prev_odom.a) * dx + cos(prev_odom.a) * dy;
-    odom.a = fmod(new_odom.a - prev_odom.a + M_PI, 2*M_PI) - M_PI;
+    odom.a = fmod(new_odom.a - prev_odom_.a + M_PI, 2*M_PI) - M_PI;
 
-    prev_odom = new_odom;
+    prev_odom_ = new_odom;
     return true;
 }  
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -68,8 +68,8 @@ bool IO::resetOdometry()
     bool newdata = comm_->readOdometryData(new_odom);
     if (!newdata)
         return false;
-    prev_odom = new_odom;
-    odom_set = true;
+    prev_odom_ = new_odom;
+    odom_set_ = true;
     return true;
 }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -43,11 +43,11 @@ bool IO::readOdometryData(OdometryData& odom)
     if (!newdata)
         return false;
 
-    if (!odom_set)
+    if (!odom_set_)
     {
         ROS_WARN("Odom was not yet set. It is set now.");
-        prev_odom = new_odom;
-        odom_set = true;
+        prev_odom_ = new_odom;
+        odom_set_ = true;
         return false;
     }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -64,8 +64,7 @@ bool IO::readOdometryData(OdometryData& odom)
 bool IO::resetOdometry()
 {
     OdometryData new_odom;
-    bool newdata = comm_->readOdometryData(new_odom);
-    if (!newdata)
+    if (!comm_->readOdometryData(new_odom))
         return false;
     prev_odom_ = new_odom;
     odom_set_ = true;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -39,8 +39,7 @@ bool IO::readLaserData(LaserData& scan)
 bool IO::readOdometryData(OdometryData& odom)
 {
     OdometryData new_odom;
-    bool newdata = comm_->readOdometryData(new_odom);
-    if (!newdata)
+    if (!comm_->readOdometryData(new_odom))
         return false;
 
     if (!odom_set_)

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -43,6 +43,14 @@ bool IO::readOdometryData(OdometryData& odom)
     if (!newdata)
         return false;
 
+    if (!odom_set)
+    {
+        ROS_WARN("Odom was not yet set. It is set now.");
+        prev_odom = new_odom;
+        odom_set = true;
+        return false;
+    }
+
     odom.timestamp = new_odom.timestamp; //TODO give dt?
     double dx = new_odom.x - prev_odom.x;
     double dy = new_odom.y - prev_odom.y;
@@ -56,8 +64,13 @@ bool IO::readOdometryData(OdometryData& odom)
 
 bool IO::resetOdometry()
 {
-    OdometryData odom;
-    return readOdometryData(odom);
+    OdometryData new_odom;
+    bool newdata = comm_->readOdometryData(new_odom);
+    if (!newdata)
+        return false;
+    prev_odom = new_odom;
+    odom_set = true;
+    return true;
 }
 
 bool IO::readFrontBumperData(BumperData& bumper)


### PR DESCRIPTION
changes the odometry interface from returning a pose in odometry frame (which is a very ROS way of doing things) to returning the displacement since the last function call (which is more universal).

As a result the odometry must now be set. which can be done using either resetOdometry() or by calling readOdometry() once.